### PR TITLE
len comparing of tables by own sql

### DIFF
--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -161,7 +161,7 @@ class differ:
         self.raw_db_7 = raw_db_7
 
     def _fetch_all_vals(self, db5, table_name: str, sql: str = None):
-        sql = sql = f"SELECT * FROM {table_name}" if sql is None else sql
+        sql = sql or f"SELECT * FROM {table_name}"
         cols5 = []
         db5 = db5 or self.raw_db_dspace_5
         vals5 = db5.fetch_all(sql, col_names=cols5)
@@ -213,8 +213,13 @@ class differ:
 
     def diff_table_cmp_len(self, db5, table_name: str, nonnull: list = None, gdpr: bool = True, sql: str = None):
         nonnull = nonnull or []
-        cols5, vals5, cols7, vals7 = self._fetch_all_vals(db5, table_name, sql)
+        sql_info = False
+        cols5, vals5, cols7, vals7 = self._fetch_all_vals(db5, table_name)
         do_not_show = gdpr and "email" in nonnull
+
+        if len(vals5) != len(vals7) and sql is not None:
+            cols5, vals5, cols7, vals7 = self._fetch_all_vals(db5, table_name, sql)
+            sql_info = True
 
         msg = " OK " if len(vals5) == len(vals7) else " !!! WARN !!! "
         _logger.info(
@@ -229,7 +234,8 @@ class differ:
             msg = " OK " if len(vals5_cmp) == len(vals7_cmp) else " !!! WARN !!! "
             _logger.info(
                 f"Table [{table_name: >20}] {msg}  NON NULL [{col_name:>15}] v5:[{len(vals5_cmp):3}], v7:[{len(vals7_cmp):3}]")
-        if sql is not None:
+
+        if sql_info:
             _logger.info(
                 f"Table [{table_name: >20}]  !!! WARN !!!  SQL request: {sql}")
 

--- a/src/pump/_db.py
+++ b/src/pump/_db.py
@@ -161,7 +161,7 @@ class differ:
         self.raw_db_7 = raw_db_7
 
     def _fetch_all_vals(self, db5, table_name: str, sql: str = None):
-        sql = f"SELECT * FROM {table_name}"
+        sql = sql = f"SELECT * FROM {table_name}" if sql is None else sql
         cols5 = []
         db5 = db5 or self.raw_db_dspace_5
         vals5 = db5.fetch_all(sql, col_names=cols5)
@@ -211,9 +211,9 @@ class differ:
             return
         self._cmp_values(table_name, vals5, only_in_5, vals7, only_in_7, do_not_show)
 
-    def diff_table_cmp_len(self, db5, table_name: str, nonnull: list = None, gdpr: bool = True):
+    def diff_table_cmp_len(self, db5, table_name: str, nonnull: list = None, gdpr: bool = True, sql: str = None):
         nonnull = nonnull or []
-        cols5, vals5, cols7, vals7 = self._fetch_all_vals(db5, table_name)
+        cols5, vals5, cols7, vals7 = self._fetch_all_vals(db5, table_name, sql)
         do_not_show = gdpr and "email" in nonnull
 
         msg = " OK " if len(vals5) == len(vals7) else " !!! WARN !!! "
@@ -229,6 +229,9 @@ class differ:
             msg = " OK " if len(vals5_cmp) == len(vals7_cmp) else " !!! WARN !!! "
             _logger.info(
                 f"Table [{table_name: >20}] {msg}  NON NULL [{col_name:>15}] v5:[{len(vals5_cmp):3}], v7:[{len(vals7_cmp):3}]")
+        if sql is not None:
+            _logger.info(
+                f"Table [{table_name: >20}]  !!! WARN !!!  SQL request: {sql}")
 
     def diff_table_sql(self, db5, table_name: str, sql5, sql7, compare, process_ftor):
         cols5 = []
@@ -273,6 +276,10 @@ class differ:
                 # compare only len
                 if len(defin) == 0:
                     self.diff_table_cmp_len(db5, table_name)
+
+                cmp = defin.get("len", None)
+                if cmp is not None:
+                    self.diff_table_cmp_len(db5, table_name, None, True, cmp["sql"])
 
                 cmp = defin.get("sql", None)
                 if cmp is not None:

--- a/src/pump/_item.py
+++ b/src/pump/_item.py
@@ -25,7 +25,6 @@ class items:
         ["workspaceitem", {
         }],
         ["collection2item", {
-            # In version 5, there are duplicates
             "len": {
                 "sql": "select distinct collection_id, item_id from public.collection2item group by collection_id, item_id",
             }

--- a/src/pump/_item.py
+++ b/src/pump/_item.py
@@ -25,6 +25,10 @@ class items:
         ["workspaceitem", {
         }],
         ["collection2item", {
+            # In version 5, there are duplicates
+            "len": {
+                "sql": "select distinct collection_id, item_id from public.collection2item group by collection_id, item_id",
+            }
         }],
     ]
 


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0.5  |  0  |    0 |    0 |      0 |         0 |
| Review             |  0  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |

**Problem**
Table [ collection2item] !!! WARN !!! compared by len only v5:[67146], v7:[66929]
Explanation: In version 6, there is redundant data, whereas in version 7, only unique values are present.

I've added a new condition to the validation table for custom SQL definitions to compare table lengths.
