### PR TITLE
Resource policies duplicity

### DIFF
--- a/src/pump/_collection.py
+++ b/src/pump/_collection.py
@@ -33,6 +33,7 @@ class collections:
 
         self._logos = {}
         self._groups_id2uuid = {}
+        self._groups_uuid2type = {}
 
         if len(self._col) == 0:
             _logger.info(f"Empty input collections: [{col_file_str}].")
@@ -80,6 +81,10 @@ class collections:
     @property
     def groups_id2uuid(self):
         return self._groups_id2uuid
+
+    @property
+    def groups_uuid2type(self):
+        return self._groups_uuid2type
 
     @time_method
     def import_to(self, dspace, handles, metadatas, coms):
@@ -150,6 +155,7 @@ class collections:
                     resp = dspace.put_collection_bitstream_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
+                    self._groups_uuid2type[resp['id']] = "BITSTREAM"
                 except Exception as e:
                     _logger.error(
                         f'put_collection_bitstream_read_group: [{col_id}] failed [{str(e)}]')
@@ -158,6 +164,7 @@ class collections:
                     resp = dspace.put_collection_item_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
+                    self._groups_uuid2type[resp['id']] = "ITEM"
                 except Exception as e:
                     _logger.error(
                         f'put_collection_item_read_group: [{col_id}] failed [{str(e)}]')
@@ -172,6 +179,7 @@ class collections:
             "logos": self._logos,
             "groups_id2uuid": self._groups_id2uuid,
             "imported": self._imported,
+            "groups_uuid2type": self._groups_uuid2type,
         }
         serialize(file_str, data)
 
@@ -183,3 +191,4 @@ class collections:
         self._logos = data["logos"]
         self._groups_id2uuid = data["groups_id2uuid"]
         self._imported = data["imported"]
+        self._groups_uuid2type = data["groups_uuid2type"]

--- a/src/pump/_collection.py
+++ b/src/pump/_collection.py
@@ -88,6 +88,8 @@ class collections:
 
     @time_method
     def import_to(self, dspace, handles, metadatas, coms):
+        ITEM = "ITEM"
+        BITSTREAM = "BITSTREAM"
         expected = len(self)
         log_key = "collections"
         log_before_import(log_key, expected)
@@ -155,7 +157,7 @@ class collections:
                     resp = dspace.put_collection_bitstream_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
-                    self._groups_uuid2type[resp['id']] = "BITSTREAM"
+                    self._groups_uuid2type[resp['id']] = BITSTREAM
                 except Exception as e:
                     _logger.error(
                         f'put_collection_bitstream_read_group: [{col_id}] failed [{str(e)}]')
@@ -164,7 +166,7 @@ class collections:
                     resp = dspace.put_collection_item_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
-                    self._groups_uuid2type[resp['id']] = "ITEM"
+                    self._groups_uuid2type[resp['id']] = ITEM
                 except Exception as e:
                     _logger.error(
                         f'put_collection_item_read_group: [{col_id}] failed [{str(e)}]')

--- a/src/pump/_collection.py
+++ b/src/pump/_collection.py
@@ -20,6 +20,8 @@ class collections:
     ]
 
     TYPE = 3
+    ITEM = "ITEM"
+    BITSTREAM = "BITSTREAM"
 
     def __init__(self, col_file_str: str, com2col_file_str: str, metadata_file_str: str):
         self._col = read_json(col_file_str)
@@ -88,8 +90,6 @@ class collections:
 
     @time_method
     def import_to(self, dspace, handles, metadatas, coms):
-        ITEM = "ITEM"
-        BITSTREAM = "BITSTREAM"
         expected = len(self)
         log_key = "collections"
         log_before_import(log_key, expected)
@@ -157,7 +157,7 @@ class collections:
                     resp = dspace.put_collection_bitstream_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
-                    self._groups_uuid2type[resp['id']] = BITSTREAM
+                    self._groups_uuid2type[resp['id']] = collections.BITSTREAM
                 except Exception as e:
                     _logger.error(
                         f'put_collection_bitstream_read_group: [{col_id}] failed [{str(e)}]')
@@ -166,7 +166,7 @@ class collections:
                     resp = dspace.put_collection_item_read_group(col_uuid)
                     self._groups_id2uuid.setdefault(str(group_col), []).append(resp['id'])
                     self._imported["group"] += 1
-                    self._groups_uuid2type[resp['id']] = ITEM
+                    self._groups_uuid2type[resp['id']] = collections.ITEM
                 except Exception as e:
                     _logger.error(
                         f'put_collection_item_read_group: [{col_id}] failed [{str(e)}]')

--- a/src/pump/_resourcepolicy.py
+++ b/src/pump/_resourcepolicy.py
@@ -116,7 +116,7 @@ class resourcepolicies:
                         if group in group_types and group_types[group] == target_type
                     ]
 
-                    if len(group_type_list) > 1:
+                    if len(group_type_list) != 1:
                         raise RuntimeError(
                             f'Unexpected size of filtered groups for group [{eg_id}] '
                             f'of type [{target_type}]: {len(group_type_list)}. Expected size: 1.'

--- a/src/pump/_resourcepolicy.py
+++ b/src/pump/_resourcepolicy.py
@@ -19,6 +19,8 @@ class resourcepolicies:
             "respol": 0,
         }
 
+    DEFAULT_BITSTREAM_READ = "DEFAULT_BITSTREAM_READ"
+
     def __len__(self):
         return len(self._respol)
 
@@ -32,7 +34,6 @@ class resourcepolicies:
 
     @time_method
     def import_to(self, env, dspace, repo):
-        DEFAULT_BITSTREAM_READ = "DEFAULT_BITSTREAM_READ"
         expected = len(self)
         log_key = "resourcepolicies"
         log_before_import(log_key, expected)
@@ -98,15 +99,30 @@ class resourcepolicies:
                 if len(group_list) == 0:
                     continue
                 if len(group_list) > 1:
+                    if len(group_list) != 2:
+                        raise RuntimeError(
+                            f'Unexpected size of mapped groups to group [{eg_id}]: {len(group_list)}. '
+                            f'Expected size: 2.')
                     group_types = repo.collections.groups_uuid2type
                     # Determine the target type based on the action
-                    target_type = repo.collections.BITSTREAM \
-                        if dspace_actions[actionId] == DEFAULT_BITSTREAM_READ else repo.collections.ITEM
-                    # Filter group_list to find the appropriate group based on type
-                    for group in group_list:
-                        if group in group_types and group_types[group] == target_type:
-                            group_list = [group]
-                            break
+                    target_type = (
+                        repo.collections.BITSTREAM
+                        if dspace_actions[actionId] == resourcepolicies.DEFAULT_BITSTREAM_READ
+                        else repo.collections.ITEM
+                    )
+                    # Filter group_list to find the appropriate group based on type using list comprehension
+                    group_type_list = [
+                        group for group in group_list
+                        if group in group_types and group_types[group] == target_type
+                    ]
+
+                    if len(group_type_list) > 1:
+                        raise RuntimeError(
+                            f'Unexpected size of filtered groups for group [{eg_id}] '
+                            f'of type [{target_type}]: {len(group_type_list)}. Expected size: 1.'
+                        )
+
+                    group_list = group_type_list
 
                 imported_groups = 0
                 for group in group_list:

--- a/src/pump/_resourcepolicy.py
+++ b/src/pump/_resourcepolicy.py
@@ -33,8 +33,6 @@ class resourcepolicies:
     @time_method
     def import_to(self, env, dspace, repo):
         DEFAULT_BITSTREAM_READ = "DEFAULT_BITSTREAM_READ"
-        ITEM = "ITEM"
-        BITSTREAM = "BITSTREAM"
         expected = len(self)
         log_key = "resourcepolicies"
         log_before_import(log_key, expected)
@@ -102,7 +100,8 @@ class resourcepolicies:
                 if len(group_list) > 1:
                     group_types = repo.collections.groups_uuid2type
                     # Determine the target type based on the action
-                    target_type = BITSTREAM if dspace_actions[actionId] == DEFAULT_BITSTREAM_READ else ITEM
+                    target_type = repo.collections.BITSTREAM \
+                        if dspace_actions[actionId] == DEFAULT_BITSTREAM_READ else repo.collections.ITEM
                     # Filter group_list to find the appropriate group based on type
                     for group in group_list:
                         if group in group_types and group_types[group] == target_type:

--- a/src/repo_import.py
+++ b/src/repo_import.py
@@ -282,7 +282,7 @@ if __name__ == "__main__":
     # created data
     repo.raw_db_7.delete_resource_policy()
 
-    # import bitstreams
+    # import resourcepolicy
     cache_file = env["cache"]["resourcepolicy"]
     if deserialize(args.resume, repo.resourcepolicies, cache_file):
         _logger.info(f"Resuming resourcepolicies [{repo.resourcepolicies.imported}]")

--- a/src/repo_import.py
+++ b/src/repo_import.py
@@ -278,15 +278,14 @@ if __name__ == "__main__":
     repo.diff(repo.usermetadatas)
     _logger.info(import_sep)
 
-    # before importing of resource policies we have to delete all
-    # created data
-    repo.raw_db_7.delete_resource_policy()
-
     # import resourcepolicy
     cache_file = env["cache"]["resourcepolicy"]
     if deserialize(args.resume, repo.resourcepolicies, cache_file):
         _logger.info(f"Resuming resourcepolicies [{repo.resourcepolicies.imported}]")
     else:
+        # before importing of resource policies we have to delete all
+        # created data
+        repo.raw_db_7.delete_resource_policy()
         repo.resourcepolicies.import_to(env, dspace_be, repo)
         repo.resourcepolicies.serialize(cache_file)
     repo.diff(repo.resourcepolicies)


### PR DESCRIPTION
| Phases            | MP | MM  |  MB  | MR |   JM | Total  |
|-----------------|----:|----:|----:|-----:|-----:|-------:|
| ETA                  |  0  |  0  |    0 |     0 |      0 |        0 |
| Developing      |  0  |  0  |    0 |    0 |      0 |         0 |
| Review             |  3  |  0  |    0 |    0 |      0 |         0 |
| Total                |   -  |   -  |   -   |  -    |   -    |         0 |
| ETA est.             |      |      |       |       |         |         0 |
| ETA cust.           |   -  |   -  |   -  |   -   |   -     |        0 |
## Problem description
You can see duplication in the Restricted Collection: Wikitongues Oral Histories and in all collections where the Authorization Action is READ, DEFAULT_ITEM_READ, or DEFAULT_BITSTREAM_READ.
image

## Analysis
This issue occurs because in DSpace 5, there is only a DEFAULT_READ group for the actions BITSTREAM_DEFAULT_READ and ITEM_DEFAULT_READ. In DSpace 7, these are divided into separate ITEM_DEFAULT_READ and BITSTREAM_DEFAULT_READ groups. Consequently, one group from DSpace 5 is mapped to two groups in DSpace 7.

## Solution
Since one group in DSpace 5 is split into two groups in DSpace 7, these groups are assigned the same e-persons (the only difference is in their names). Assign the READ and ITEM_DEFAULT_READ actions only to the group named COLLECTION_[uuid]ITEM_DEFAULT_READ and the BITSTREAM_DEFAULT_READ action to the group named COLLECTION[uuid]_BITSTREAM_DEFAULT_READ.

Old implementation:
![image](https://github.com/user-attachments/assets/4700ede5-0009-4a3e-b8be-786c89d9c88f)

New implementation:
![image](https://github.com/user-attachments/assets/d68e983b-eb52-486a-a219-b588dc3e63ec)
![image](https://github.com/user-attachments/assets/e5565cfa-cf61-46c8-ba8f-96f3212c027d)
